### PR TITLE
updating version of babel-plugin-module-resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "autoprefixer": "7.1.5",
-    "babel-plugin-module-resolver": "^2.7.1",
+    "babel-plugin-module-resolver": "^3.1.1",
     "babel-plugin-wrap-in-js": "^1.1.0",
     "glob": "^7.1.2",
     "next": "latest",


### PR DESCRIPTION
User gets an error "Module build failed: TypeError: Cannot read property '1' of undefined" when using older version of babel-plugin-module-resolver